### PR TITLE
Use ctrl-q shortcut instead of cmd-q on Mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 			{
 				"command": "extension.gotoLastEditLocation",
 				"key": "ctrl+q",
-				"mac": "cmd+q",
+				"mac": "ctrl+q",
 				"when": "editorTextFocus"
 			}
 		]


### PR DESCRIPTION
Cmd-q on mac is the shortcut to close VSCode. Ctrl-q doesn't seem to be used for anything.
